### PR TITLE
Save the download log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ venv
 .idea
 apache/osm-reporter.apache.conf
 reporter/config/local.py
+osm-reporter-download.csv
 components/
 data
 *~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ db:
 
 web:
   image: kartoza/osm-reporter
+  #build: .
+  #dockerfile: Dockerfile
   hostname: web
   container_name: osmreporter_web
   environment:
@@ -20,6 +22,7 @@ web:
     - db:db
   volumes:
     - ./reporter:/reporter
+    - ./log:/log
 
 dev:
   build: .

--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/reporter/config/default.py
+++ b/reporter/config/default.py
@@ -11,5 +11,7 @@ BBOX = '20.411482,-34.053726,20.467358,-34.009483'
 DISPLAY_UPDATE_CONTROL = True
 # Where to store OSM files
 CACHE_DIR = '/tmp'
+# Download log file
+DOWNLOAD_LOG_FILE = '/log/osm-reporter-download.csv'
 # Options for the osm2pgsql command line
 OSM2PGSQL_OPTIONS = ''

--- a/reporter/views.py
+++ b/reporter/views.py
@@ -15,6 +15,7 @@ from . import app
 from . import config
 from .utilities import (
     split_bbox,
+    log_request,
     osm_object_contributions,
     get_totals, osm_nodes_by_user)
 from .osm import (
@@ -120,6 +121,16 @@ def download_feature(feature_type):
     else:
         try:
             file_handle = get_osm_file(coordinates, feature_type, 'body')
+
+            # We log the download.
+            log_request(
+                request.remote_addr,
+                feature_type,
+                bbox,
+                qgis_version,
+                inasafe_version,
+                lang)
+
         except urllib2.URLError:
             # error = "Bad request. Maybe the bbox is too big!"
             abort(500)


### PR DESCRIPTION
Save the download log as a CSV in /log/osm-reporter-download.csv
It can be easily open with QGIS. We save the geometry as a WKT.

@timlinux, is-it the best way to keep log ? Is-it privacy compliance ?